### PR TITLE
update unit_price 

### DIFF
--- a/target_easyecom/sinks.py
+++ b/target_easyecom/sinks.py
@@ -47,8 +47,8 @@ class BuyOrdersSink(EasyecomSink):
                     line_item["sku"] = item.get("sku")
                 if item.get("quantity"):
                     line_item["quantity"] = item.get("quantity")
-                if item.get("unit_price"):
-                    line_item["unitPrice"] = item.get("unit_price")
+                if "unit_price" in item:
+                    line_item["unitPrice"] = item["unit_price"]
                 if item.get("tax_amount"):
                     line_item["taxValue"] = item.get("tax_amount")
                 if line_item:


### PR DESCRIPTION
updated unitPrice value mapping to allow value =0

If order has only one line, unitPrice must be sent or export will fail. 
As it was, if value =0, the unitPrice property was not included in payload
If order has more lines, unitPrice missing does not returns error.
